### PR TITLE
proxy XHR to get image data

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -38,7 +38,7 @@
 	};
 
 	BackgroundPage.prototype.onMessageFromWoker = function(ev) {
-		var	result = ev.data.result,
+		var result = ev.data.result,
 			data = ev.data.data,
 			tabId = ev.data.tabId;
 
@@ -49,7 +49,7 @@
 			result: result,
 			data: data
 		});
-	}
+	};
 
 	BackgroundPage.prototype.addMessageListener = function(type, listener) {
 		this._messageListeners[type] = listener;
@@ -82,7 +82,10 @@
 	// Request cache of image
 
 	BackgroundPage.prototype.onImageCacheMessage = function(tabId, url) {
-		this._worker.postMessage({url: url, tabId: tabId});
+		this._worker.postMessage({
+			url: url,
+			tabId: tabId
+		});
 	};
 
 	//--------------------------------------------------------------------------

--- a/scripts/content_scripts.js
+++ b/scripts/content_scripts.js
@@ -150,7 +150,7 @@
 
 	ContentScript.prototype.appendItems = function($parent, children) {
 		var listener = function(ev) {
-			this.$.originalFocusedElement.value = ev.target.src;
+			this.$.originalFocusedElement.value = ev.target.dataset.url;
 			this.closeBase();
 		}.bind(this);
 
@@ -159,6 +159,7 @@
 
 			$child.classList.add('stampImage');
 			$child.id = children[i].url;
+			$child.dataset.url = children[i].proxiedUrl;
 			$child.dataset.clipboardText = children[i].proxiedUrl;
 			$child.setAttribute('tabindex', 0);
 			$child.addEventListener('click', listener);

--- a/scripts/content_scripts.js
+++ b/scripts/content_scripts.js
@@ -114,7 +114,13 @@
 	ContentScript.prototype.onImageCacheMessage = function(result, data) {
 		if (result) {
 			var $img = document.getElementById(data.proxiedUrl);
-			$img.src = data.objectUrl;
+			var xhr = new XMLHttpRequest();
+			xhr.open('GET', data.objectUrl);
+			xhr.responseType = 'blob';
+			xhr.onload = function() {
+				$img.src = URL.createObjectURL(xhr.response)
+			};
+			xhr.send();
 		} else {
 			console.error('Error in background page');
 			console.error(data);

--- a/scripts/content_scripts.js
+++ b/scripts/content_scripts.js
@@ -109,7 +109,7 @@
 			type: '/image/cache',
 			data: url
 		});
-	}
+	};
 
 	ContentScript.prototype.onImageCacheMessage = function(result, data) {
 		if (result) {
@@ -118,14 +118,14 @@
 			xhr.open('GET', data.objectUrl);
 			xhr.responseType = 'blob';
 			xhr.onload = function() {
-				$img.src = URL.createObjectURL(xhr.response)
+				$img.src = URL.createObjectURL(xhr.response);
 			};
 			xhr.send();
 		} else {
 			console.error('Error in background page');
 			console.error(data);
 		}
-	}
+	};
 
 	//--------------------------------------------------------------------------
 	// UI management

--- a/scripts/worker.js
+++ b/scripts/worker.js
@@ -1,3 +1,4 @@
+/* global requestFileSystemSync, TEMPORARY */
 
 (function(global) {
 	'use strict';
@@ -7,13 +8,13 @@
 
 	function Worker() {
 		this.setupWorker();
-	};
+	}
 
 	Worker.prototype.setupWorker = function() {
 		global.addEventListener('message', this.onMessage.bind(this), false);
 		global.requestFileSystemSync = global.webkitRequestFileSystemSync ||
-																	global.requestFileSystemSync;
-  }
+			global.requestFileSystemSync;
+	};
 
 	//--------------------------------------------------------------------------
 	// Listener
@@ -59,25 +60,30 @@
 
 	Worker.prototype.pGetFileEntry = function(url) {
 		var filePath = encodeURIComponent(url);
-		var fs = requestFileSystemSync(TEMPORARY, 1024*1024);
+		var fs = requestFileSystemSync(TEMPORARY, 1024 * 1024);
 		return new Promise(function(resolve) {
 			console.log('in promise of pGetFileEntry');
-			var fileEntry = fs.root.getFile(filePath, {create: false});
+			var fileEntry = fs.root.getFile(filePath, {
+				create: false
+			});
 			resolve(fileEntry.file());
 		});
 	};
 
 	Worker.prototype.pWriteFile = function(url) {
 		var filePath = encodeURIComponent(url);
-		var fs = requestFileSystemSync(TEMPORARY, 1024*1024);
-		return new Promise(function(resolve, reject) {
+		var fs = requestFileSystemSync(TEMPORARY, 1024 * 1024);
+		return new Promise(function(resolve) {
 			this.pFetchImageWithUrl(url)
-			.then(function(blob) {
-				console.log('in promise of pWriteFile');
-				var fileEntry = fs.root.getFile(filePath, {create: true, exclusive: false});
-				fileEntry.createWriter().write(blob);
-				resolve(fileEntry.file());
-			});
+				.then(function(blob) {
+					console.log('in promise of pWriteFile');
+					var fileEntry = fs.root.getFile(filePath, {
+						create: true,
+						exclusive: false
+					});
+					fileEntry.createWriter().write(blob);
+					resolve(fileEntry.file());
+				});
 		}.bind(this));
 	};
 
@@ -86,18 +92,13 @@
 
 	Worker.prototype.pFetchImageWithUrl = function(url) {
 		return fetch(url)
-		.then(function(res) {
-			return res.blob();
-		});
+			.then(function(res) {
+				return res.blob();
+			});
 	};
 
 	//--------------------------------------------------------------------------
 	// Private
-
-	function errorHandler(err) {
-		console.error('ERROR has occured: ' + err);
-		postMessage('ERROR: ' + err);
-	};
 
 	global.worker = new Worker();
 })(self);

--- a/scripts/worker.js
+++ b/scripts/worker.js
@@ -22,94 +22,103 @@
 	// Listener
 
 	Worker.prototype.onMessage = function(ev) {
-		console.log(ev.data.url);
-		this.pGetFileEntry(ev.data.url)
-			.catch(this.pHandleCacheMissedError(ev.data.url))
-			.then(this.pipeSuccessMessage(ev.data.url, ev.data.tabId))
-			.catch(this.pipeErrorMessage(ev.data.url, ev.data.tabId));
+		var url = ev.data.url;
+
+		console.log(url);
+
+		this.pFindOrCreateCache(url)
+			.then(this.formatResponseData.bind(this, url))
+			.then(this.pipeSuccessMessage.bind(this, url, ev.data.tabId))
+			.catch(this.pipeErrorMessage.bind(this, url, ev.data.tabId));
 	};
 
 	//--------------------------------------------------------------------------
 	// Pipe
 
-	Worker.prototype.pipeSuccessMessage = function(url, tabId) {
-		return function(file) {
-			console.log('pipeSuccessMessage');
-			global.postMessage({
-				result: true,
-				data: {
-					objectUrl: URL.createObjectURL(file),
-					proxiedUrl: url
-				},
-				tabId: tabId
-			});
-		};
+	Worker.prototype.pipeSuccessMessage = function(url, tabId, data) {
+		console.log('pipeSuccessMessage');
+		global.postMessage({
+			result: true,
+			data: data,
+			tabId: tabId
+		});
 	};
 
-	Worker.prototype.pipeErrorMessage = function(url, tabId) {
-		return function(err) {
-			console.log('pipeErrorMessage');
-			global.postMessage({
-				result: false,
-				data: err,
-				tabId: tabId
-			});
+	Worker.prototype.pipeErrorMessage = function(url, tabId, err) {
+		console.log('pipeErrorMessage');
+		global.postMessage({
+			result: false,
+			data: err,
+			tabId: tabId
+		});
+	};
+
+	Worker.prototype.formatResponseData = function(url, blob) {
+		return {
+			objectUrl: URL.createObjectURL(blob),
+			proxiedUrl: url
 		};
 	};
 
 	//--------------------------------------------------------------------------
 	// FileSystem API
 
-	Worker.prototype.pGetFileEntry = function(url) {
-		var filePath = encodeURIComponent(url);
+	Worker.prototype.pFindOrCreateCache = function(url) {
+		return this.pReadFile(url2filePath(url))
+			.catch(this.pCreateCache.bind(this, url));
+	};
+
+	Worker.prototype.pReadFile = function(filePath) {
 		var fs = this.fs;
+
 		return new Promise(function(resolve) {
-			console.log('in promise of pGetFileEntry');
-			var fileEntry = fs.root.getFile(filePath, {
-				create: false
-			});
-			resolve(fileEntry.file());
+			var blob = fs.root
+				.getFile(filePath, {
+					create: false
+				})
+				.file();
+
+			resolve(blob);
 		});
 	};
 
-	Worker.prototype.pHandleCacheMissedError = function(url) {
-		return function(err) {
-			console.info('Cache is missed!');
-			console.info(err);
-
-			return this.pWriteFile(url);
-		}.bind(this);
-	};
-
-	Worker.prototype.pWriteFile = function(url) {
-		var filePath = encodeURIComponent(url);
+	Worker.prototype.pWriteFile = function(filePath, blob) {
 		var fs = this.fs;
 
-		return this.pFetchImageWithUrl(url)
-			.then(function(blob) {
-				console.log('in promise of pWriteFile');
-				var fileEntry = fs.root.getFile(filePath, {
+		return new Promise(function(resolve) {
+			fs.root
+				.getFile(filePath, {
 					create: true,
 					exclusive: false
-				});
-				fileEntry.createWriter().write(blob);
+				})
+				.createWriter().write(blob);
 
-				return fileEntry.file();
-			});
+			resolve(blob);
+		});
+	};
+
+	Worker.prototype.pCreateCache = function(url) {
+		return this.pFetchImageWithUrl(url)
+			.then(this.pWriteFile.bind(this, url2filePath(url)));
 	};
 
 	//--------------------------------------------------------------------------
 	// Fetch
 
 	Worker.prototype.pFetchImageWithUrl = function(url) {
-		return fetch(url)
-			.then(function(res) {
-				return res.blob();
-			});
+		return fetch(url).then(res2blob);
 	};
 
 	//--------------------------------------------------------------------------
 	// Private
+
+	function res2blob(res) {
+		return res.blob();
+	}
+
+	function url2filePath(url) {
+		return encodeURIComponent(url);
+	}
 
 	global.worker = new Worker();
 })(self);


### PR DESCRIPTION
## 原因
- `Object.createObjectURL` で作成されたURLは、作成された `document` 内でのみ有効
- 今回の場合は, **WW** で作成したURLは **BG** でしか使えない。( **BG** と **CS** は完全に別のページ)
## 解決方法
- XHRはドメイン間通信ができる
- つまり、別 `document` で生成したURLにもアクセスできる
- XHRを使って、**WW** 側で作ったURLにアクセス、File(Blob)を取得し、URLを再生成する
- このURLは **CS** 側の `document` で作られているため、 **CS** からアクセス出来る
- ✌ ('ω' ✌ )三 ✌ ('ω') ✌ 三( ✌ 'ω') ✌ 
